### PR TITLE
Feature/v2 work api derivation focus, DLX API Specification Updates - Clarifications and Cleanup

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,7 +12,7 @@ Die DLX (DICOM Link Exchange) API basiert ursprünglich auf der deutschen DIN-No
 
 **Version:** 2.0  
 **Basis:** DIN/TS 19455:2025-03
-**Letzte Aktualisierung:** März 2026
+**Letzte Aktualisierung:** April 2026
 
 ---
 
@@ -34,54 +34,13 @@ Vollständiges CRUD für DLX-Token-Links mit Paginierung, Filterung und Token-De
 - **Filterung** - Filtern nach `patientId`, `studyInstanceUid`, `accessionNumber`
 - **Token-Derivation** - Erstellen abgeleiteter Token mit eingeschränktem Scope
 
-**Security:** `adminOidcAuth` mit `dlx.creator`/`dlx.admin` oder `bearerAuth` mit `dlx.derive`
+**Security:** `bearerAuth` mit `dlx.derive` Scope
 
----
-
-### 2. OIDC-Authentifizierung
-
-Professionelle Authentifizierung für administrative Endpoints.
-
-**Neuer Endpoint:**
-- `GET /.well-known/openid-configuration` - OIDC Discovery Document (RFC 8414)
-
-**Neue Security-Schemes:**
-- `adminOidcAuth` - OpenID Connect für administrative Endpoints
-
-**OAuth 2.0 Scopes:**
-- `dlx.creator` - Erstellen und Verwalten von Token-Links
-- `dlx.importer` - Importieren externer DLX-Links
-- `dlx.admin` - Vollständiger Admin-Zugriff (überschreibt andere Scopes)
-
----
-
-### 3. Import-Funktionalität
-
-Austausch von Daten zwischen DLX-Systemen.
-
-**Neuer Endpoint:**
-- `POST /import` - Importieren externer DLX-Links
-
-**Beschreibung:**
-- Importiert Daten von einem externen DLX-Link
-- Synchroner Trigger mit asynchronem Hintergrundprozess
-- Sofortige Antwort (200) oder Status-Update (202) mit `statusUrl`
-
-**Security:** `adminOidcAuth` mit `dlx.importer` oder `dlx.admin` Scope
-
----
-
-### 4. DICOMweb-Integration
-
-Unterstützung für DICOMweb-Dienste (WADO-RS und QIDO-RS) zur direkten Abfrage von DICOM-Daten.
-
-**Neue Capability:** `dicomweb` in `/api_info`
-
-Die `dicomweb` Capability in der `/api_info` Antwort gibt an, ob WADO-RS (Retrieve) und QIDO-RS (Query) für DICOM-Daten verfügbar sind. DLX Bearer-Tokens können für die Authentifizierung an diesen Endpoints verwendet werden, eingeschränkt auf die Study UIDs des jeweiligen Tokens.
-
-**JWT-Authentifizierung:**
-- DLX Bearer-Token wird für DICOMweb-Endpoints akzeptiert
-- Eingeschränkt auf Study UIDs des Tokens
+**Wichtige Hinweise:**
+- Der `dlx.derive` Scope wird nur vergeben, wenn der erstellende Token mit `allowDerivation: true` erstellt wurde
+- Bei Verwendung von bearerAuth für DLX-Creator Endpunkte müssen die erstellten/aktualisierten Token ein Subset der erstellenden Token-Berechtigungen sein
+- `expiresAt` darf nicht über die Gültigkeit des erstellenden Tokens hinausgehen
+- Die Datenobjekte (Studien) können eingeschränkt werden (weniger Studien als Eltern-Token)
 
 ---
 
@@ -101,22 +60,25 @@ Die `dicomweb` Capability in der `/api_info` Antwort gibt an, ob WADO-RS (Retrie
 #### DLX-Creator (Token-Management)
 | Endpoint | Methode | Auth | Beschreibung |
 |------|---------|------|-----------|
-| `/tokens` | POST | OIDC/Bearer | Token erstellen |
-| `/tokens` | GET | OIDC/Bearer | Alle Token auflisten (paginiert) |
-| `/tokens/{token}` | GET | OIDC/Bearer | Token-Details |
-| `/tokens/{token}` | PUT | OIDC/Bearer | Token aktualisieren |
-| `/tokens/{token}` | DELETE | OIDC/Bearer | Token löschen |
+| `/tokens` | POST | Bearer¹ | Token erstellen |
+| `/tokens` | GET | Bearer¹ | Alle Token auflisten (paginiert) |
+| `/tokens/{token}` | GET | Bearer¹ | Token-Details |
+| `/tokens/{token}` | PUT | Bearer¹ | Token aktualisieren |
+| `/tokens/{token}` | DELETE | Bearer¹ | Token löschen |
 
-#### DLX-Importer (Data Import)
-| Endpoint | Methode | Auth | Beschreibung |
-|------|---------|------|-----------|
-| `/import` | POST | OIDC | Externen DLX-Link importieren |
+¹ Bearer mit `dlx.derive` Scope für Token Derivation (nur eigene abgeleitete Tokens)
+
+**Wichtige Hinweise:**
+- Der `dlx.derive` Scope wird nur vergeben, wenn der erstellende Token mit `allowDerivation: true` erstellt wurde
+- Bei Verwendung von bearerAuth für DLX-Creator Endpunkte müssen die erstellten/aktualisierten Token ein Subset der erstellenden Token-Berechtigungen sein
+- `expiresAt` darf nicht über die Gültigkeit des erstellenden Tokens hinausgehen
+- Die Datenobjekte (Studien) können eingeschränkt werden (weniger Studien als Eltern-Token)
 
 #### Info
 | Endpoint | Methode | Auth | Beschreibung |
 |------|---------|------|-----------|
 | `/api_info` | GET | None | API-Version und Capabilities |
-| `/.well-known/openid-configuration` | GET | None | OIDC Discovery Document |
+| `/tfa_info` | GET | Bearer | Unterstützte TFA-Optionen (authentifiziert) |
 
 ---
 
@@ -124,12 +86,11 @@ Die `dicomweb` Capability in der `/api_info` Antwort gibt an, ob WADO-RS (Retrie
 
 ### JWT Bearer Authentication
 - **Scope:** `dlx.consumer` - Download-Endpoints
-- **Scope:** `dlx.derive` - Token-Derivation über `/tokens`
+- **Scope:** `dlx.derive` - Token-Management über `/tokens`
 
-### OpenID Connect
-- **Scope:** `dlx.creator` - Token-Management
-- **Scope:** `dlx.importer` - Import-Endpoints
-- **Scope:** `dlx.admin` - Vollständiger Admin-Zugriff
+**Wichtige Hinweise:**
+- Der `dlx.derive` Scope wird nur vergeben, wenn der erstellende Token mit `allowDerivation: true` erstellt wurde
+- Bei Verwendung von bearerAuth für DLX-Creator Endpunkte müssen die erstellten/aktualisierten Token ein Subset der erstellenden Token-Berechtigungen sein
 
 ---
 
@@ -139,8 +100,6 @@ Die `dicomweb` Capability in der `/api_info` Antwort gibt an, ob WADO-RS (Retrie
 |------|-----|---|
 | `download` | boolean | DLX-Consumer Endpoints (token, list, download, downloadall) |
 | `tokens` | boolean | Token-Management Endpoints (POST/GET/PUT/DELETE /tokens) |
-| `import` | boolean | Import-Endpoint (/import) |
-| `oidc` | boolean | OIDC Discovery Endpoint (/.well-known/openid-configuration) |
 | `derivation` | boolean | Token-Derivation (erstellen abgeleiteter Token) |
 | `dicomweb` | object | DICOMweb-Capabilities (WADO-RS, QIDO-RS) für direkte DICOM-Abfrage |
 
@@ -150,5 +109,5 @@ Die `dicomweb` Capability in der `/api_info` Antwort gibt an, ob WADO-RS (Retrie
 
 | Version | Datum | Änderungen |
 |---------|-----|--------|
-| **2.0** | März 2026 | Token-Management, OIDC-Authentifizierung, Import-Funktionalität, DICOMweb-Integration |
+| **2.0** | April 2026 | Token-Management, bearerAuth mit dlx.derive für DLX-Creator, DICOMweb-Integration |
 | **1.0** | März 2025 | DIN/TS 19455:2025-03 |

--- a/README.md
+++ b/README.md
@@ -10,21 +10,29 @@ Die **DLX API** (DICOM Link Exchange) ist eine Initiative von Herstellern medizi
 ## Hauptmerkmale
 
 - 🔐 **Zwei-Faktor-Authentifizierung (TFA)** für sicheren Patienten-Zugriff
-- 🔑 **OpenID Connect (OIDC)** für administrative Zugriffe
-- 📦 **IHE PDI konforme** DICOM-Downloads
-- 🔄 **Import-Funktionalität** für externen Datenaustausch
+- � **IHE PDI konforme** DICOM-Downloads
 - 🌳 **Token Derivation** für eingeschränkte Untertokens
 - 🏥 **DICOMweb-Integration** für WADO-RS und QIDO-RS Zugriff
 
 ## API-Rollen
 
-Die DLX API unterscheidet drei Hauptrollen:
+Die DLX API unterscheidet zwei Hauptrollen:
 
 | Rolle | Beschreibung | Authentifizierung |
 |-------|--------------|-------------------|
 | **DLX-Consumer** | Patienten/Ärzte, die Daten über Token-Links herunterladen | TFA → JWT |
-| **DLX-Creator** | Administratoren, die Token-Links erstellen und verwalten | OIDC (Scope: `dlx.creator`) |
-| **DLX-Importer** | Systeme, die Daten von externen DLX-Instanzen importieren | OIDC (Scope: `dlx.importer`) |
+| **DLX-Creator** | Benutzer/Admins, die Token-Links erstellen und verwalten | JWT (Scope: `dlx.derive`) |
+
+**JWT Scopes:**
+
+| Scope | Beschreibung |
+|-------|--------------|
+| `dlx.consumer` | Zugriff auf Download-Endpunkte (/list, /download, /downloadall) |
+| `dlx.derive` | Token-Links erstellen und verwalten (DLX-Creator Endpunkte) |
+
+**Wichtige Hinweise:**
+- Der `dlx.derive` Scope wird nur vergeben, wenn der erstellende Token mit `allowDerivation: true` erstellt wurde
+- Bei Verwendung von bearerAuth für DLX-Creator Endpunkte müssen die erstellten/aktualisierten Token ein Subset der erstellenden Token-Berechtigungen sein (expiresAt nicht später, weniger Datenobjekte)
 
 ---
 
@@ -45,26 +53,20 @@ Patienten oder Ärzte erhalten einen Token-Link (z.B. per E-Mail oder QR-Code) u
 
 ### DLX-Creator Workflow
 
-Administratoren erstellen Token-Links für Patienten, um diesen Zugriff auf ihre medizinischen Daten zu gewähren.
+Benutzer/Admins erstellen Token-Links für Patienten, um diesen Zugriff auf ihre medizinischen Daten zu gewähren.
 
 ![DLX-Creator Workflow](workflow-creator.png)
 
 **Schritte:**
-1. **OIDC-Login**: Authentifizierung mit `dlx.creator` Scope
+1. **JWT mit dlx.derive Scope**: Token muss `allowDerivation: true` haben
 2. **Token erstellen**: `POST /tokens` mit Patienten- und Studiendaten
 3. **TFA konfigurieren**: Optional Sicherheitsfragen definieren
 4. **Link versenden**: Token-Link an Patienten senden
 
-### DLX-Importer Workflow
-
-Systeme importieren Daten von externen DLX-Instanzen (z.B. andere Krankenhäuser).
-
-![DLX-Importer Workflow](workflow-importer.png)
-
-**Schritte:**
-1. **OIDC-Login**: Authentifizierung mit `dlx.importer` Scope
-2. **Import anstoßen**: `POST /import` mit externem Link und TFA-Daten
-3. **Daten empfangen**: Synchron (200) oder asynchron (202)
+**Wichtige Hinweise:**
+- Bei Verwendung von bearerAuth für DLX-Creator Endpunkte müssen die erstellten Token ein Subset der erstellenden Token-Berechtigungen sein
+- `expiresAt` darf nicht über die Gültigkeit des erstellenden Tokens hinausgehen
+- Die Datenobjekte (Studien) können eingeschränkt werden (weniger Studien als Eltern-Token)
 
 ### DICOMweb WADO-RS Workflow
 
@@ -92,7 +94,7 @@ DLX-Consumer mit `dlx.derive` Scope können eingeschränkte Untertokens für Dri
 **Schritte:**
 1. **TFA-Authentifizierung**: Normaler DLX-Consumer Workflow
 2. **JWT mit dlx.derive Scope**: Token muss `allowDerivation: true` haben
-3. **Untertoken erstellen**: `POST /tokens` mit Bearer-Token (nicht OIDC)
+3. **Untertoken erstellen**: `POST /tokens` mit Bearer-Token
 4. **Eingeschränkter Zugriff**: Untertoken kann nur Subset der Eltern-Studien und kürzere Gültigkeit haben
 
 **Einschränkungen für abgeleitete Tokens:**
@@ -109,7 +111,6 @@ DLX-Consumer mit `dlx.derive` Scope können eingeschränkte Untertokens für Dri
 | Endpunkt | Methode | Beschreibung |
 |----------|---------|--------------|
 | `/api_info` | GET | API-Version und unterstützte Capabilities |
-| `/.well-known/openid-configuration` | GET | OIDC Discovery Document |
 | `/tfa_info` | GET | Unterstützte TFA-Optionen (authentifiziert) |
 
 ### DLX-Consumer Endpunkte
@@ -126,19 +127,19 @@ DLX-Consumer mit `dlx.derive` Scope können eingeschränkte Untertokens für Dri
 
 | Endpunkt | Methode | Auth | Beschreibung |
 |----------|---------|------|--------------|
-| `/tokens` | GET | OIDC / JWT¹ | Alle Token-Links auflisten (paginiert) |
-| `/tokens` | POST | OIDC / JWT¹ | Neuen Token-Link erstellen |
-| `/tokens/{token}` | GET | OIDC / JWT¹ | Token-Link-Details abrufen |
-| `/tokens/{token}` | PUT | OIDC / JWT¹ | Token-Link aktualisieren |
-| `/tokens/{token}` | DELETE | OIDC / JWT¹ | Token-Link löschen |
+| `/tokens` | GET | JWT¹ | Alle Token-Links auflisten (paginiert) |
+| `/tokens` | POST | JWT¹ | Neuen Token-Link erstellen |
+| `/tokens/{token}` | GET | JWT¹ | Token-Link-Details abrufen |
+| `/tokens/{token}` | PUT | JWT¹ | Token-Link aktualisieren |
+| `/tokens/{token}` | DELETE | JWT¹ | Token-Link löschen |
 
 ¹ JWT mit `dlx.derive` Scope für Token Derivation (nur eigene abgeleitete Tokens)
 
-#### Token mit Derivation erstellen (OIDC)
+#### Token mit Derivation erstellen
 
 ```json
 POST /tokens
-Authorization: Bearer {oidc_access_token}
+Authorization: Bearer {jwt_with_dlx_derive_scope}
 
 {
   "patientId": "PID123",
@@ -160,6 +161,12 @@ Authorization: Bearer {oidc_access_token}
   "tfaAnswer": [...]
 }
 ```
+
+**Wichtige Hinweise:**
+- Der `dlx.derive` Scope wird nur vergeben, wenn der erstellende Token mit `allowDerivation: true` erstellt wurde
+- Bei Verwendung von bearerAuth für DLX-Creator Endpunkte müssen die erstellten Token ein Subset der erstellenden Token-Berechtigungen sein
+- `expiresAt` darf nicht über die Gültigkeit des erstellenden Tokens hinausgehen
+- Die Datenobjekte (Studien) können eingeschränkt werden (weniger Studien als Eltern-Token)
 
 #### Abgeleiteten Token erstellen (JWT mit dlx.derive)
 
@@ -188,12 +195,6 @@ Authorization: Bearer {jwt_with_dlx_derive_scope}
   "tfaAnswer": [...]
 }
 ```
-
-### DLX-Importer Endpunkte
-
-| Endpunkt | Methode | Auth | Beschreibung |
-|----------|---------|------|--------------|
-| `/import` | POST | OIDC | Daten von externem DLX importieren |
 
 ---
 
@@ -230,10 +231,11 @@ Authorization: Bearer {jwt_with_dlx_derive_scope}
 | Scope | Beschreibung |
 |-------|--------------|
 | `dlx.consumer` | Zugriff auf Download-Endpunkte (/list, /download, /downloadall) |
-| `dlx.derive` | Eingeschränkte Untertokens erstellen (Token Derivation) |
-| `dlx.creator` | Token-Links erstellen und verwalten |
-| `dlx.importer` | Externe DLX-Daten importieren |
-| `dlx.admin` | Vollständiger administrativer Zugriff (inkl. creator + importer) |
+| `dlx.derive` | Token-Links erstellen und verwalten (DLX-Creator Endpunkte) |
+
+**Wichtige Hinweise:**
+- Der `dlx.derive` Scope wird nur vergeben, wenn der erstellende Token mit `allowDerivation: true` erstellt wurde
+- Bei Verwendung von bearerAuth für DLX-Creator Endpunkte müssen die erstellten/aktualisierten Token ein Subset der erstellenden Token-Berechtigungen sein
 
 ---
 
@@ -260,8 +262,6 @@ Die `/api_info`-Endpunkt gibt Auskunft über unterstützte Features:
   "capabilities": {
     "download": true,
     "tokens": true,
-    "import": false,
-    "oidc": true,
     "derivation": true,
     "dicomweb": {
       "wadoRs": {
@@ -280,8 +280,6 @@ Die `/api_info`-Endpunkt gibt Auskunft über unterstützte Features:
 |------------|--------------|
 | `download` | DLX-Consumer Endpunkte verfügbar |
 | `tokens` | DLX-Creator Endpunkte verfügbar |
-| `import` | DLX-Importer Endpunkte verfügbar |
-| `oidc` | OIDC Discovery verfügbar |
 | `derivation` | Token Derivation unterstützt (dlx.derive Scope) |
 | `dicomweb` | DICOMweb-Dienste (WADO-RS, QIDO-RS) verfügbar |
 
@@ -364,8 +362,7 @@ npx swagger-ui-watcher openapi.yaml
 
 ## Weitere Informationen
 
-- **OpenAPI Spezifikation**: [`openapi.yaml`](openapi.yaml)
-- **OIDC Discovery 1.0**: https://openid.net/specs/openid-connect-discovery-1_0.html
+- **OpenAPI Spezifikation**: [`dicomLinkExchange.yaml`](dicomLinkExchange.yaml)
 - **IHE PDI Profile**: https://www.ihe.net/resources/profiles/
 
 ---

--- a/dicomLinkExchange.yaml
+++ b/dicomLinkExchange.yaml
@@ -23,47 +23,6 @@ paths:
               schema:
                 $ref: '#/components/schemas/apiInfo'
 
-  /.well-known/openid-configuration:
-    description: |
-      OpenID Connect (OIDC) Discovery endpoint scoped within the DLX base path
-      (e.g. /dlx/v1/.well-known/openid-configuration). This avoids conflicts with a potentially
-      existing system-level /.well-known/openid-configuration.
-      Implementations may either serve the OIDC configuration directly (HTTP 200) or redirect
-      (HTTP 302) to an external IDP or the system-level /.well-known/openid-configuration.
-      This endpoint is optional; its availability is indicated by the 'oidc' capability in /api_info.
-    get:
-      operationId: getOidcConfiguration
-      summary: OpenID Connect Discovery Document
-      description: |
-        Returns the OpenID Connect Discovery Document (RFC 8414 / OIDC Discovery 1.0)
-        for DLX administrative authentication. Two implementation patterns are supported:
-        1. **Direct**: The server returns the OIDC configuration directly (HTTP 200).
-        2. **Redirect**: The server redirects to an external IDP's discovery endpoint (HTTP 302).
-        If not implemented, HTTP 501 is returned.
-      tags:
-        - Info
-      responses:
-        "200":
-          description: |
-            OIDC Discovery Document returned successfully.
-            The response format follows RFC 8414 / OpenID Connect Discovery 1.0.
-            DLX-specific scopes (dlx.creator, dlx.importer, dlx.admin) are listed in scopes_supported.
-          content:
-            application/json:
-              schema:
-                type: object
-                description: RFC 8414 / OIDC Discovery 1.0 document. See https://openid.net/specs/openid-connect-discovery-1_0.html
-        "302":
-          description: Redirect to an external IDP's OIDC discovery endpoint.
-          headers:
-            Location:
-              schema:
-                type: string
-                format: uri
-              description: URL of the external IDP's OIDC discovery endpoint.
-        "501":
-          description: Not implemented. This server does not expose an OIDC discovery endpoint.
-
   /token/{value}:
     description: The initial call which accepts only the token (e.g. from a link or QR code) and responds with the TFA questions for the calling system to generate a JWT for all further requests. To enhance security, this call always returns successfully, even if the token value does not actually exist. The feedback on failed or successful authentication is provided by the subsequent /tokentfa/{value} endpoint. To enable the DLX functionalities the HTTP header parameter X-DICOM-LINK-EXCHANGE is required. This allowes pre-existing token URLs to forward to this API endpoint (e.g. https://example.com/portal?token={value} with a HTTP header X-DICOM-LINK-EXCHANGE should return the same result as the defined DLX endpoint https://example.com/dlx/v1/token/{value}) .
     get:
@@ -193,12 +152,14 @@ paths:
       summary: Get supported two-factor authentication (TFA) options
       description: |
         Returns information about supported two-factor authentication (TFA) options.
+        
+        To use this endpoint with bearerAuth, the JWT must contain the dlx.derive scope.
+        The dlx.derive scope is only granted when the creating token was created with allowDerivation set to true.
       tags:
         - DLX-Creator
         - Info
       security:
-        - adminOidcAuth: [dlx.creator]
-        - adminOidcAuth: [dlx.admin]
+        - bearerAuth: [dlx.derive]
       responses:
         "200":
           description: Supported TFA options returned successfully.
@@ -218,6 +179,13 @@ paths:
       description: |
         Creates a DLX token link that grants access to download one or more DICOM studies.
         Optional two-factor authentication (TFA) methods can be configured to protect the link.
+        
+        To use this endpoint with bearerAuth, the JWT must contain the dlx.derive scope.
+        The dlx.derive scope is only granted when the creating token was created with allowDerivation set to true.
+        When using bearerAuth, the created token must be a subset of the creating token's permissions:
+        - The expiresAt date cannot be later than the creating token's expiresAt
+        - The data items (studies) cannot exceed those allowed by the creating token
+        - The allowDerivation flag cannot be set to true unless the creating token has derivation enabled
       tags:
         - DLX-Creator
       requestBody:
@@ -242,8 +210,6 @@ paths:
         "500":
           description: Internal server error.
       security:
-        - adminOidcAuth: [dlx.creator]
-        - adminOidcAuth: [dlx.admin]
         - bearerAuth: [dlx.derive]
     get:
       operationId: listTokens
@@ -251,6 +217,9 @@ paths:
       description: |
         Returns a paginated list of all DLX token links with metadata.
         Pagination follows RFC 8288 semantics. The response contains pagination metadata and the list of token links.
+        
+        To use this endpoint with bearerAuth, the JWT must contain the dlx.derive scope.
+        The dlx.derive scope is only granted when the creating token was created with allowDerivation set to true.
       tags:
         - DLX-Creator
       parameters:
@@ -317,14 +286,16 @@ paths:
         "500":
           description: Internal server error.
       security:
-        - adminOidcAuth: [dlx.creator]
-        - adminOidcAuth: [dlx.admin]
         - bearerAuth: [dlx.derive]
   /tokens/{token}:
     get:
       operationId: getToken
       summary: Get details of a DLX token link
-      description: Returns details for a single DLX token link.
+      description: |
+        Returns details for a single DLX token link.
+        
+        To use this endpoint with bearerAuth, the JWT must contain the dlx.derive scope.
+        The dlx.derive scope is only granted when the creating token was created with allowDerivation set to true.
       tags:
         - DLX-Creator
       parameters:
@@ -348,13 +319,19 @@ paths:
         "500":
           description: Internal server error.
       security:
-        - adminOidcAuth: [dlx.creator]
-        - adminOidcAuth: [dlx.admin]
         - bearerAuth: [dlx.derive]
     put:
       operationId: updateToken
       summary: Update a DLX token link
-      description: Updates the properties of an existing DLX token link.
+      description: |
+        Updates the properties of an existing DLX token link.
+        
+        To use this endpoint with bearerAuth, the JWT must contain the dlx.derive scope.
+        The dlx.derive scope is only granted when the creating token was created with allowDerivation set to true.
+        When using bearerAuth, the updated token must be a subset of the creating token's permissions:
+        - The expiresAt date cannot be later than the creating token's expiresAt
+        - The data items (studies) cannot exceed those allowed by the creating token
+        - The allowDerivation flag cannot be set to true unless the creating token has derivation enabled
       tags:
         - DLX-Creator
       parameters:
@@ -386,13 +363,15 @@ paths:
         "500":
           description: Internal server error.
       security:
-        - adminOidcAuth: [dlx.creator]
-        - adminOidcAuth: [dlx.admin]
         - bearerAuth: [dlx.derive]
     delete:
       operationId: deleteToken
       summary: Delete a DLX token link
-      description: Deletes a DLX token link and revokes access.
+      description: |
+        Deletes a DLX token link and revokes access.
+        
+        To use this endpoint with bearerAuth, the JWT must contain the dlx.derive scope.
+        The dlx.derive scope is only granted when the creating token was created with allowDerivation set to true.
       tags:
         - DLX-Creator
       parameters:
@@ -412,46 +391,7 @@ paths:
         "500":
           description: Internal server error.
       security:
-        - adminOidcAuth: [dlx.creator]
-        - adminOidcAuth: [dlx.admin]
         - bearerAuth: [dlx.derive]
-
-  /import:
-    post:
-      operationId: import
-      summary: Import data from an external DLX link
-      description: |
-        Triggers the import of data from an external DLX link (token) and immediately returns a response. The actual data transfer is processed asynchronously in the background. If the import completes within a short time (e.g., 10 seconds), a 200 response with the imported data is returned. If the import takes longer, a 202 response is returned, optionally including a statusUrl for tracking the import progress. The statusUrl allows the provider to supply a page or API endpoint for status updates; its usage is implementation-specific.
-      tags:
-        - DLX-Importer
-      requestBody:
-        description: Parameters for importing an external DLX link.
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/importRequest'
-      responses:
-        "200":
-          description: Import completed. Metadata returned.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/importResponse'
-        "202":
-          description: Import started. Transfer initiated successfully.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/importResponse'
-        "400":
-          description: Bad request.
-        "401":
-          description: Not authorized.
-        "500":
-          description: Internal server error.
-      security:
-        - adminOidcAuth: [dlx.importer]
-        - adminOidcAuth: [dlx.admin]
 
 components:
   securitySchemes:
@@ -467,19 +407,11 @@ components:
         - `dlx.derive` - Additional access to create derived tokens via /tokens endpoint
         
         When using /tokens endpoints with bearerAuth, the JWT must contain `dlx.derive` scope.
-
-    # --- Proposal: Link Creation ---
-    adminOidcAuth:
-      type: openIdConnect
-      openIdConnectUrl: .well-known/openid-configuration
-      description: |
-        OpenID Connect (OIDC) authentication for DLX administrative operations (DLX-Creator and DLX-Importer).
-        The openIdConnectUrl is relative to the DLX server base path and resolves to
-        {apiBasePath}/.well-known/openid-configuration (e.g. /dlx/v1/.well-known/openid-configuration).
-        DLX-defined OAuth 2.0 scopes:
-        * `dlx.creator`  - Create and manage DLX token links (DLX-Creator endpoints)
-        * `dlx.importer` - Import data from external DLX links (DLX-Importer endpoints)
-        * `dlx.admin`    - Full administrative access; supersedes (includes dlx.creator and dlx.importer)
+        The dlx.derive scope is only granted when the creating token was created with allowDerivation set to true.
+        When creating or updating tokens via bearerAuth, the resulting token must be a subset of the creating token's permissions:
+        - expiresAt cannot exceed the creating token's expiration
+        - Data items cannot exceed those allowed by the creating token
+        - allowDerivation cannot be enabled unless the creating token permits it
 
   # --- Proposal: Capabilities ---
   schemas:
@@ -499,7 +431,7 @@ components:
           capabilities:
               type: object
               description: |
-                Indicates which optional features/endpoints are supported by this implementation. Example: { "download": true, "tokens": true, "import": false }
+                Indicates which optional features/endpoints are supported by this implementation. Example: { "download": true, "tokens": true }
               properties:
                   download:
                       type: boolean
@@ -507,12 +439,6 @@ components:
                   tokens:
                       type: boolean
                       description: Whether the /tokens endpoint is supported.
-                  import:
-                      type: boolean
-                      description: Whether the /import endpoint is supported.
-                  oidc:
-                      type: boolean
-                      description: Whether the .well-known/openid-configuration endpoint (scoped under the DLX base path) is supported for OIDC-based administrative authentication.
                   derivation:
                       type: boolean
                       description: Whether token derivation is supported (creating derived tokens via /tokens endpoint with dlx.derive scope).
@@ -527,8 +453,6 @@ components:
           capabilities:
               download: true
               tokens: true
-              import: false
-              oidc: true
               derivation: true
               dicomweb:
                   wadoRs:
@@ -738,7 +662,7 @@ components:
         allowDerivation:
           type: boolean
           default: false
-          description: Whether the created token can create further derived tokens. Only applicable when creating tokens via adminOidcAuth or when the creating token has dlx.derive scope.
+          description: Whether the created token can create further derived tokens. When set to true, the token can be used to access DLX-Creator endpoints via bearerAuth with the dlx.derive scope.
       example:
         patientId: PID123
         studyInstanceUids:
@@ -777,7 +701,7 @@ components:
           $ref: '#/components/schemas/dataItems'
         allowDerivation:
           type: boolean
-          description: Whether this token can create derived tokens via the /tokens endpoint.
+          description: Whether this token can create derived tokens via the /tokens endpoint. When true, the token can be used to access DLX-Creator endpoints via bearerAuth with the dlx.derive scope.
         parentToken:
           type: string
           description: Parent token value if this is a derived token. Only present for derived tokens.
@@ -901,47 +825,6 @@ components:
                   patientsBirthdate: 19700101
                   patientsSex: M
 
-    # --- Proposal: Link Import ---
-    importRequest:
-      type: object
-      required:
-        - link
-        - token
-        - tfaAnswer
-      description: Request to import an external DLX link.
-      properties:
-        link:
-          type: string
-          description: External DLX link (URL).
-        token:
-          type: string
-          description: Token value from the external DLX link.
-        tfaAnswer:
-          type: array
-          items:
-            $ref: '#/components/schemas/tfaAnswer'
-          description: Answers to TFA questions.
-    importResponse:
-      type: object
-      description: Response with status and metadata about the import.
-      properties:
-        status:
-          type: string
-          description: Status of the import. Possible values started, completed, error, partial.
-          enum:
-            - started
-            - completed
-            - error
-            - partial
-        statusUrl:
-          type: string
-          description: Optional URL to a status page where users can track the import progress (implementation-specific).
-        importedItems:
-          $ref: '#/components/schemas/dataItems'
-        message:
-          type: string
-          description: Optional status or error message.
-
     dateTime:
       description: Date and time in ISO 8601 format (e.g., 2022-03-10T16:15:50Z).
       format: date-time
@@ -1036,7 +919,5 @@ tags:
     description: APIs used to download and access medical data via DLX token links.
   - name: DLX-Creator
     description: APIs used to create and manage DLX token links.
-  - name: DLX-Importer
-    description: APIs used to import and transfer data from external DLX token links.    
   - name: Info
     description: Provides information on version and implemented capabilities of the API


### PR DESCRIPTION
## Summary

This PR updates the DLX API OpenAPI specification with improved clarity on bearerAuth token restrictions and removes deprecated functionality (OIDC authentication and import endpoints).

## Changes Overview

### 1. Enhanced Token Operation Descriptions

Updated `createToken`, `updateToken`, `getToken`, `deleteToken`, `listTokens`, and `/tfa_info` endpoints to clarify:

- The `dlx.derive` scope is required for DLX-Creator access
- The `dlx.derive` scope is only granted when the creating token was created with `allowDerivation: true`
- When using bearerAuth, the created/updated token must be a subset of the creating token's permissions:
  - `expiresAt` cannot be later than the creating token's `expiresAt`
  - Data items (studies) cannot exceed those allowed by the creating token
  - The `allowDerivation` flag cannot be set to true unless the creating token has derivation enabled

### 2. Updated bearerAuth Security Scheme

- Clarified that `dlx.derive` scope is required for DLX-Creator endpoints
- Added explicit note that `dlx.derive` scope is only granted when `allowDerivation: true`
- Added subset restriction requirements for bearerAuth token creation/update

### 3. Updated allowDerivation Field Descriptions

- Clarified that `allowDerivation: true` is the prerequisite for accessing DLX-Creator endpoints via bearerAuth
- Updated both `tokensRequest.allowDerivation` and `tokensResponse.allowDerivation` descriptions

### 4. Removed OIDC Functionality

- Removed `.well-known/openid-configuration` endpoint
- Removed `adminOidcAuth` security scheme
- Removed all `adminOidcAuth` references from endpoints
- Removed OIDC capability from `apiInfo` schema

### 5. Removed Import Functionality

- Removed `/import` endpoint
- Removed `importRequest` and `importResponse` schemas
- Removed `DLX-Importer` tag from tags section

## Technical Details

**Files Modified:**
- `dicomLinkExchange.yaml` - Complete OpenAPI specification

**Breaking Changes:**
- None (removal of optional features only)

**Migration Notes:**
- Systems using OIDC authentication should migrate to JWT bearer authentication
- Systems using import functionality should implement alternative data transfer mechanisms

## Related Issues

- Clarifies token derivation restrictions
- Removes deprecated functionality

## Checklist

- [x] All OIDC references removed
- [x] Import section completely removed
- [x] BearerAuth descriptions updated with subset constraints
- [x] YAML syntax validated
- [x] No breaking changes introduced
